### PR TITLE
Set minimum go version to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gowebapi/webidl-bind
 
-go 1.18
+go 1.17
 
 require (
 	github.com/gowebapi/webidlparser v0.0.0-20190714100300-8be816faf6ec
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/gowebapi/webapi v0.0.0-20220111173747-55340d8985e9 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gowebapi/webapi v0.0.0-20220111173747-55340d8985e9 h1:1yMeROaiaJzPaVmnrDYCLoIMHeDkyb2q+qsW9WaID2k=
+github.com/gowebapi/webapi v0.0.0-20220111173747-55340d8985e9/go.mod h1:VnFFpbgBz6cR+Qlrw3sXh4TX7O8QCABPaZLkExT5YVI=
 github.com/gowebapi/webidlparser v0.0.0-20190714100300-8be816faf6ec h1:fp0nM5jP6jODheHoX61TPosa+qsrj6a44tG2vISW4sg=
 github.com/gowebapi/webidlparser v0.0.0-20190714100300-8be816faf6ec/go.mod h1:NcX8WFnRoi5F3LHUWPGItC602aLfeDCC6UjiRf4pYcU=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
* Tested on Go 1.17.5 and 1.18.beta1.…
* Also updated the version dependency on webapi to the latest one, with the new `core.Wrapper` definition copied from js.Wrapper being dropped.
