### PR TITLE
JSValue() returns js.Null() if the object is nil

### DIFF
--- a/gowasm/interface.go
+++ b/gowasm/interface.go
@@ -22,7 +22,11 @@ type {{.Type.Def}} struct {
 }
 
 {{if not .If.Inherits}}
+// JSValue returns the js.Value or js.Null() if _this is nil
 func (_this *{{.Type.Def}}) JSValue() js.Value {
+	if _this == nil {
+		return js.Null()
+	}
 	return _this.Value_JS
 }
 {{end}}


### PR DESCRIPTION
See https://github.com/gowebapi/webapi/issues/20 for background information
